### PR TITLE
Use previous state as initial guess to improve solver convergence

### DIFF
--- a/integrators/integrators.py
+++ b/integrators/integrators.py
@@ -75,15 +75,15 @@ def get_dormand_prince_solver(rhs, dt):
 
 def get_crank_nicolson_solver(rhs, dt, solver=None):
     if solver is None:
-        solver = lambda A, b: jax.jit(jax.scipy.sparse.linalg.cg, static_argnums=(0,))(
-            A, b
-        )[0]
+        solver = lambda A, b, x0: jax.jit(
+            jax.scipy.sparse.linalg.cg, static_argnums=(0,)
+        )(A, b, x0)[0]
 
     @jax.jit
     def integrate(t, y, dt=dt, rhs=rhs, solver=solver):
         A = lambda c, t=t, dt=dt, rhs=rhs: c - dt / 2 * rhs(t + dt / 2, c)
         b = y + dt / 2 * rhs(t + dt / 2, y)
 
-        return t + dt, solver(A, b)
+        return t + dt, solver(A, b, y)
 
     return integrate


### PR DESCRIPTION
By using the state in the current time step as an initial guess for the state in the next time step, the convergence of the linear solver should improve.